### PR TITLE
Typo in name gives compiler warning

### DIFF
--- a/dribbbledanimation/pubspec.yaml
+++ b/dribbbledanimation/pubspec.yaml
@@ -1,4 +1,4 @@
-name: dribbdledanimation
+name: dribbbledanimation
 description: A new Flutter project.
 
 dependencies:


### PR DESCRIPTION
Because of the typo can't compile the project.